### PR TITLE
versatile sub function

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -17,3 +17,4 @@ There are also longer scripts that can be useful:
 |[smpe_list.py](smpe_list.py)|Sample code showing how to convert from JCL to Python using the list feature of SMPE.|
 |[SMPElistDefaults.yaml](SMPElistDefaults.yaml)|Definitions that smpe_list.py needs. Must be put in the same directory as smpe_list.py. Changes need to be made to match users system|
 |[console.sh](console.sh)|Run opercmd interactively| 
+|[runjcl.py](runjcl.py)| submit a JCL job and print job status | 

--- a/samples/runjcl.py
+++ b/samples/runjcl.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+""" Copyright IBM Corp 2021.
+    Submits a JCL job and returns status output in a Python dictionary
+"""
+
+import argparse
+import textwrap
+import time
+
+from zoautil_py import datasets, exceptions, jobs
+
+
+def runjob(jcl_ds: str):
+    """This function will submit a JCL job
+
+    Args:
+        jcl_ds (str): data set name to submit
+
+    Returns:
+        dictionary: Python dictionary of job status - NAME, OWNER, STATUS, RC
+    """
+    status_record = []
+    current_status = {}
+    # In case JCL job hangs, it will timeout at 70 seconds.
+    # This time can be adjusted.
+    timeoutsec = 70
+    try:
+        if datasets.exists(jcl_ds) is True:
+            job_submitted = jobs.submit(jcl_ds, timeout=timeoutsec)
+        else:
+            print("Dataset not found, check that it exist")
+            return -1
+    except exceptions.ZOAUException:
+        print("Invalid input")
+        return -1
+
+    print("Job " + job_submitted.name + " submitted")
+    # status will be stored / displayed until ACTIVE status changes
+    while (job_submitted.status == "AC"):
+        current_status = _set_current_status(job_submitted)
+        print(current_status)
+        # Keep a record of statuses in a list of dictionaries
+        status_record.append(current_status)
+        # sleep for three seconds, adjust if more time is needed
+        time.sleep(3)
+        job_submitted.refresh()
+
+    # return final status and add it to list for record keeping
+    current_status = _set_current_status(job_submitted)
+    status_record.append(current_status)
+    return current_status
+
+
+def _print_to_log(status_record: list):
+    """ Module can be called to write the record of statuses to a file.
+        Record will be overwritten everytime script is ran to prevent file
+        from getting too large.
+
+        NOTE: Currently this module is not being called from anywhere *
+
+    Args:
+        status_record (list): list of Python dictionaries of JCL status results
+    """
+    output_log = open("log_out.txt", "w")
+    output_log.write(str(status_record))
+
+
+def _set_current_status(job_submitted):
+    """Sets Name, owner, status, and rc of submitted JCL job
+
+    Args:
+        job_submitted (object):  Job object representing the submitted dataset
+    """
+    return {'NAME': job_submitted.name,
+            'OWNER': job_submitted.owner,
+            'STATUS': job_submitted.status,
+            'RC': job_submitted.rc
+            }
+
+
+def _parse_arguments():
+    """
+    Process arguments for script
+    """
+    parse_input = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=textwrap.dedent('''
+                Example:
+                runjob.py "MY.DATASET(JCLJOB)"
+                '''))
+    parse_input.add_argument('dataset',
+                             help="Enter job dataset to submit",
+                             type=str)
+    argument = parse_input.parse_args()
+    return argument
+
+
+def main():
+    argument = _parse_arguments()
+    print(runjob(argument.dataset))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
```
from zoautil_py.jobs     import listing
from subprocess          import run        
from traceback           import print_tb
from sys                 import exc_info                                    
from time                import sleep
from datetime            import datetime, timedelta    

def sub(jclin,encode=False,pipe=False,timeout=10):
    """Submit a JCL containing job using either a file or a string object. 
       Wrapped around /bin/submit and /bin/cat mimicing:  cat file | submit

       Parameters:                         
       
       jclin  : (str) a MVS or an USS file name or a string object
       encode : (Boolean) optional, can be set if file is UTF-8 encoded
                defaults to False --> EBCDIC (IBM-1047) encoding
       pipe   : (Boolean) optional, set to True in case you stored your JCL in a string object
                defaults to False   
       timeout: maximum wait time, defaults to 10 seconds         
       
       Examples:                                     
       
       sub(jclin="/tmp/file_utf8.jcl",encode=True)           #submit unicode file zfs
       sub(jclin="/tmp/file_ebcdic.jcl")                     #submit ebcdic file zfs
       sub("//'MYHLQ.TOOLS.JCL(TEST)'")                      #submit MVS ebcdic DS
       sub(jclin=jclstring,pipe=True)                        #submit a str object
       sub(jclin=read("MYHLQ.TOOLS.JCL(TEST)"),pipe=True)    #submit a str object using zoautil_py.datasets.read
       
       Returns:
       
       zoautil_py.types.Job object 
       
       Raises:
       
       UnicodeDecodeError              in case you omit parameter 'encode=True' for an UTF-8 file
       subprocess.CalledProcessError   in case you include 'encode=True' for an EBCDIC file 
                                       or if you omit the 'pipe=True' when using a string object
                                       
       An empty list is returned if you use parameter 'pipe=True' combined with a file or if your job resides longer on the JES input queue then expected.                           
    """                               
    
    try:                                       
        if pipe:              
            yin = jclin                    
        else:        
            if encode:                                      
                cmdparts = f"cat -W filecodeset=UTF-8,pgmcodeset=IBM-1047 {jclin}".split(' ')
            else:
                cmdparts = f"cat {jclin}".split(' ')

            x   = run(cmdparts,capture_output=True,encoding='UTF-8',check=True)
            x.check_returncode()
            yin = x.stdout          
            
        # execute submit using stdout from previous subprocess                   
        y = run(["submit","-j"],input=yin,capture_output=True,encoding='UTF-8')
        y.check_returncode()
        jobid  = y.stdout.strip()      
                                    
        timeout_time = datetime.now() + timedelta(0,timeout)
        
        while listing(jobid) == [] and timeout_time > datetime.now():
            sleep(0.5) 
                                                  
    except Exception:                                              
        print('Type: ', exc_info()[0])       
        print('Value: ', exc_info()[1])                     
        print('Traceback: ', end='')                          
        print_tb(exc_info()[2])                                                                   
                                                  
    finally:                                   
       return listing(jobid)                
```
                                                                    
       